### PR TITLE
Change returned value of `emoji_str()`

### DIFF
--- a/helpers/paginator.py
+++ b/helpers/paginator.py
@@ -589,7 +589,7 @@ class CharacterInformationPageSource(menus.ListPageSource):
 
 
 def emoji_str(emoji: typing.Union[discord.Emoji, discord.PartialEmoji]) -> str:
-    return f"*`{str(emoji)}`".replace('<', '<`*`')
+    return f"*`{str(emoji)}`".replace('<', ' ')
 
 
 class EmojiListPageSource(menus.ListPageSource):


### PR DESCRIPTION
## Summary
The original function used to return the format of an emoji with the **first**`<` in an italicized manner and it was away from the colon by one space, which separates the symbols from the `name` of the emoji. 

This has been changed. Besides replacing "<" with "<`*`", I made replaced the "<" with an empty string.

This fixes it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the docstrings to reflect the changes, if applicable.
- [x] This PR fixes an issue.
- [ ] This PR is **not** a code change.
      *e.g. docstrings, command parameter descriptions, fixing a typo.*
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
