### PR TITLE
fix "Made by" to use team's owner if available

### DIFF
--- a/cogs/info.py
+++ b/cogs/info.py
@@ -815,6 +815,12 @@ class About(commands.Cog):
         """Tells you information about the bot itself."""
         await ctx.defer()
         information = await self.bot.application_info()
+
+        if information.team:
+            owner = information.team.owner or information.team.members[0]
+        else:
+            owner = information.owner
+
         embed = discord.Embed(
             description=f"{constants.GITHUB} [source]({self.bot.repo}) | "
             f"{constants.INVITE} [invite me]({self.bot.invite_url}) | "
@@ -825,8 +831,8 @@ class About(commands.Cog):
         embed.add_field(name="Latest updates:", value=get_latest_commits(limit=5), inline=False)
 
         embed.set_author(
-            name=f"Made by {information.owner}",
-            icon_url=information.owner.display_avatar.url,
+            name=f"Made by {owner}",
+            icon_url=owner.display_avatar.url,
         )
         # statistics
         total_members = 0


### PR DESCRIPTION
## Summary

Fix "made by" text in the `about` command.
> untested, lol.

## Checklist - this is a joke

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the docstrings to reflect the changes, if applicable.
- [ ] This PR fixes an issue.
- [ ] This PR is **not** a code change.
      *e.g. docstrings, command parameter descriptions, fixing a typo.*
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
